### PR TITLE
model-wrappers, discretization of sigma_hat

### DIFF
--- a/k_diffusion/external.py
+++ b/k_diffusion/external.py
@@ -16,6 +16,11 @@ class CompVisModel(AbstractModel):
     alphas_cumprod: Tensor
     def apply_model(self, x: Tensor, t: Tensor, cond: Tensor) -> Tensor: ...
 
+class WrappedModelProto(AbstractModel):
+    def sigma_to_t(self, sigma: Tensor) -> Tensor: ...
+    def t_to_sigma(self, t: Tensor) -> Tensor: ...
+    def discretize_sigma(self, sigma: Tensor) -> Tensor: ...
+
 # the 'default' arg of TypeVar isn't valid at runtime, but amazingly seems to be utilised
 # at compile-time by some type-checkers
 # https://github.com/python/mypy/issues/4236#issuecomment-344660299
@@ -28,7 +33,7 @@ else:
     TDenoiserModel = TypeVar('TDenoiserModel', bound=DenoiserModel)
     TCompVisModel = TypeVar('TCompVisModel', bound=CompVisModel)
 
-class BaseModelWrapper(nn.Module, Generic[TModel]):
+class BaseModelWrapper(nn.Module, WrappedModelProto, Generic[TModel]):
     inner_model: TModel
 
     """The base wrapper class for the k-diffusion model wrapper idiom. Model

--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -8,7 +8,7 @@ import torchsde
 from tqdm.auto import trange, tqdm
 
 from . import utils
-from .external import BaseModelWrapper
+from .external import WrappedModelProto
 
 
 def append_zero(x):
@@ -116,7 +116,7 @@ class BrownianTreeNoiseSampler:
 
 
 @torch.no_grad()
-def sample_euler(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
+def sample_euler(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
     """Implements Algorithm 2 (Euler steps) from Karras et al. (2022)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
@@ -138,7 +138,7 @@ def sample_euler(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=N
 
 
 @torch.no_grad()
-def sample_euler_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
+def sample_euler_ancestral(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with Euler method steps."""
     extra_args = {} if extra_args is None else extra_args
     noise_sampler = default_noise_sampler(x) if noise_sampler is None else noise_sampler
@@ -158,7 +158,7 @@ def sample_euler_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=None, 
 
 
 @torch.no_grad()
-def sample_heun(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
+def sample_heun(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
     """Implements Algorithm 2 (Heun steps) from Karras et al. (2022)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
@@ -188,7 +188,7 @@ def sample_heun(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=No
 
 
 @torch.no_grad()
-def sample_dpm_2(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
+def sample_dpm_2(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
     """A sampler inspired by DPM-Solver-2 and Algorithm 2 from Karras et al. (2022)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
@@ -220,7 +220,7 @@ def sample_dpm_2(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=N
 
 
 @torch.no_grad()
-def sample_dpm_2_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
+def sample_dpm_2_ancestral(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     noise_sampler = default_noise_sampler(x) if noise_sampler is None else noise_sampler
@@ -262,7 +262,7 @@ def linear_multistep_coeff(order, t, i, j):
 
 
 @torch.no_grad()
-def sample_lms(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, order=4):
+def sample_lms(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, order=4):
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
     sigmas_cpu = sigmas.detach().cpu().numpy()
@@ -282,7 +282,7 @@ def sample_lms(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=Non
 
 
 @torch.no_grad()
-def log_likelihood(model: BaseModelWrapper, x, sigma_min, sigma_max, extra_args=None, atol=1e-4, rtol=1e-4):
+def log_likelihood(model: WrappedModelProto, x, sigma_min, sigma_max, extra_args=None, atol=1e-4, rtol=1e-4):
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
     v = torch.randint_like(x, 2) * 2 - 1
@@ -336,9 +336,9 @@ class PIDStepSizeController:
 
 class DPMSolver(nn.Module):
     """DPM-Solver. See https://arxiv.org/abs/2206.00927."""
-    model: BaseModelWrapper
+    model: WrappedModelProto
 
-    def __init__(self, model: BaseModelWrapper, extra_args=None, eps_callback=None, info_callback=None):
+    def __init__(self, model: WrappedModelProto, extra_args=None, eps_callback=None, info_callback=None):
         super().__init__()
         self.model = model
         self.extra_args = {} if extra_args is None else extra_args
@@ -484,7 +484,7 @@ class DPMSolver(nn.Module):
 
 
 @torch.no_grad()
-def sample_dpm_fast(model: BaseModelWrapper, x, sigma_min, sigma_max, n, extra_args=None, callback=None, disable=None, eta=0., s_noise=1., noise_sampler=None):
+def sample_dpm_fast(model: WrappedModelProto, x, sigma_min, sigma_max, n, extra_args=None, callback=None, disable=None, eta=0., s_noise=1., noise_sampler=None):
     """DPM-Solver-Fast (fixed step size). See https://arxiv.org/abs/2206.00927."""
     if sigma_min <= 0 or sigma_max <= 0:
         raise ValueError('sigma_min and sigma_max must not be 0')
@@ -496,7 +496,7 @@ def sample_dpm_fast(model: BaseModelWrapper, x, sigma_min, sigma_max, n, extra_a
 
 
 @torch.no_grad()
-def sample_dpm_adaptive(model: BaseModelWrapper, x, sigma_min, sigma_max, extra_args=None, callback=None, disable=None, order=3, rtol=0.05, atol=0.0078, h_init=0.05, pcoeff=0., icoeff=1., dcoeff=0., accept_safety=0.81, eta=0., s_noise=1., noise_sampler=None, return_info=False):
+def sample_dpm_adaptive(model: WrappedModelProto, x, sigma_min, sigma_max, extra_args=None, callback=None, disable=None, order=3, rtol=0.05, atol=0.0078, h_init=0.05, pcoeff=0., icoeff=1., dcoeff=0., accept_safety=0.81, eta=0., s_noise=1., noise_sampler=None, return_info=False):
     """DPM-Solver-12 and 23 (adaptive step size). See https://arxiv.org/abs/2206.00927."""
     if sigma_min <= 0 or sigma_max <= 0:
         raise ValueError('sigma_min and sigma_max must not be 0')
@@ -511,7 +511,7 @@ def sample_dpm_adaptive(model: BaseModelWrapper, x, sigma_min, sigma_max, extra_
 
 
 @torch.no_grad()
-def sample_dpmpp_2s_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
+def sample_dpmpp_2s_ancestral(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     noise_sampler = default_noise_sampler(x) if noise_sampler is None else noise_sampler
@@ -545,7 +545,7 @@ def sample_dpmpp_2s_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=Non
 
 
 @torch.no_grad()
-def sample_dpmpp_sde(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None, r=1 / 2):
+def sample_dpmpp_sde(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None, r=1 / 2):
     """DPM-Solver++ (stochastic)."""
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
     noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max) if noise_sampler is None else noise_sampler
@@ -587,7 +587,7 @@ def sample_dpmpp_sde(model: BaseModelWrapper, x, sigmas, extra_args=None, callba
 
 
 @torch.no_grad()
-def sample_dpmpp_2m(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, warmup_lms=False):
+def sample_dpmpp_2m(model: WrappedModelProto, x, sigmas, extra_args=None, callback=None, disable=None, warmup_lms=False):
     """DPM-Solver++(2M)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])

--- a/k_diffusion/sampling.py
+++ b/k_diffusion/sampling.py
@@ -8,6 +8,7 @@ import torchsde
 from tqdm.auto import trange, tqdm
 
 from . import utils
+from .external import BaseModelWrapper
 
 
 def append_zero(x):
@@ -115,7 +116,7 @@ class BrownianTreeNoiseSampler:
 
 
 @torch.no_grad()
-def sample_euler(model, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
+def sample_euler(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
     """Implements Algorithm 2 (Euler steps) from Karras et al. (2022)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
@@ -123,6 +124,7 @@ def sample_euler(model, x, sigmas, extra_args=None, callback=None, disable=None,
         gamma = min(s_churn / (len(sigmas) - 1), 2 ** 0.5 - 1) if s_tmin <= sigmas[i] <= s_tmax else 0.
         eps = torch.randn_like(x) * s_noise
         sigma_hat = sigmas[i] * (gamma + 1)
+        sigma_hat = model.discretize_sigma(sigma_hat)
         if gamma > 0:
             x = x + eps * (sigma_hat ** 2 - sigmas[i] ** 2) ** 0.5
         denoised = model(x, sigma_hat * s_in, **extra_args)
@@ -136,7 +138,7 @@ def sample_euler(model, x, sigmas, extra_args=None, callback=None, disable=None,
 
 
 @torch.no_grad()
-def sample_euler_ancestral(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
+def sample_euler_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with Euler method steps."""
     extra_args = {} if extra_args is None else extra_args
     noise_sampler = default_noise_sampler(x) if noise_sampler is None else noise_sampler
@@ -156,7 +158,7 @@ def sample_euler_ancestral(model, x, sigmas, extra_args=None, callback=None, dis
 
 
 @torch.no_grad()
-def sample_heun(model, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
+def sample_heun(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
     """Implements Algorithm 2 (Heun steps) from Karras et al. (2022)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
@@ -164,6 +166,7 @@ def sample_heun(model, x, sigmas, extra_args=None, callback=None, disable=None, 
         gamma = min(s_churn / (len(sigmas) - 1), 2 ** 0.5 - 1) if s_tmin <= sigmas[i] <= s_tmax else 0.
         eps = torch.randn_like(x) * s_noise
         sigma_hat = sigmas[i] * (gamma + 1)
+        sigma_hat = model.discretize_sigma(sigma_hat)
         if gamma > 0:
             x = x + eps * (sigma_hat ** 2 - sigmas[i] ** 2) ** 0.5
         denoised = model(x, sigma_hat * s_in, **extra_args)
@@ -185,7 +188,7 @@ def sample_heun(model, x, sigmas, extra_args=None, callback=None, disable=None, 
 
 
 @torch.no_grad()
-def sample_dpm_2(model, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
+def sample_dpm_2(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, s_churn=0., s_tmin=0., s_tmax=float('inf'), s_noise=1.):
     """A sampler inspired by DPM-Solver-2 and Algorithm 2 from Karras et al. (2022)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
@@ -193,6 +196,7 @@ def sample_dpm_2(model, x, sigmas, extra_args=None, callback=None, disable=None,
         gamma = min(s_churn / (len(sigmas) - 1), 2 ** 0.5 - 1) if s_tmin <= sigmas[i] <= s_tmax else 0.
         eps = torch.randn_like(x) * s_noise
         sigma_hat = sigmas[i] * (gamma + 1)
+        sigma_hat = model.discretize_sigma(sigma_hat)
         if gamma > 0:
             x = x + eps * (sigma_hat ** 2 - sigmas[i] ** 2) ** 0.5
         denoised = model(x, sigma_hat * s_in, **extra_args)
@@ -216,7 +220,7 @@ def sample_dpm_2(model, x, sigmas, extra_args=None, callback=None, disable=None,
 
 
 @torch.no_grad()
-def sample_dpm_2_ancestral(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
+def sample_dpm_2_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     noise_sampler = default_noise_sampler(x) if noise_sampler is None else noise_sampler
@@ -258,7 +262,7 @@ def linear_multistep_coeff(order, t, i, j):
 
 
 @torch.no_grad()
-def sample_lms(model, x, sigmas, extra_args=None, callback=None, disable=None, order=4):
+def sample_lms(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, order=4):
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
     sigmas_cpu = sigmas.detach().cpu().numpy()
@@ -278,7 +282,7 @@ def sample_lms(model, x, sigmas, extra_args=None, callback=None, disable=None, o
 
 
 @torch.no_grad()
-def log_likelihood(model, x, sigma_min, sigma_max, extra_args=None, atol=1e-4, rtol=1e-4):
+def log_likelihood(model: BaseModelWrapper, x, sigma_min, sigma_max, extra_args=None, atol=1e-4, rtol=1e-4):
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])
     v = torch.randint_like(x, 2) * 2 - 1
@@ -332,8 +336,9 @@ class PIDStepSizeController:
 
 class DPMSolver(nn.Module):
     """DPM-Solver. See https://arxiv.org/abs/2206.00927."""
+    model: BaseModelWrapper
 
-    def __init__(self, model, extra_args=None, eps_callback=None, info_callback=None):
+    def __init__(self, model: BaseModelWrapper, extra_args=None, eps_callback=None, info_callback=None):
         super().__init__()
         self.model = model
         self.extra_args = {} if extra_args is None else extra_args
@@ -479,7 +484,7 @@ class DPMSolver(nn.Module):
 
 
 @torch.no_grad()
-def sample_dpm_fast(model, x, sigma_min, sigma_max, n, extra_args=None, callback=None, disable=None, eta=0., s_noise=1., noise_sampler=None):
+def sample_dpm_fast(model: BaseModelWrapper, x, sigma_min, sigma_max, n, extra_args=None, callback=None, disable=None, eta=0., s_noise=1., noise_sampler=None):
     """DPM-Solver-Fast (fixed step size). See https://arxiv.org/abs/2206.00927."""
     if sigma_min <= 0 or sigma_max <= 0:
         raise ValueError('sigma_min and sigma_max must not be 0')
@@ -491,7 +496,7 @@ def sample_dpm_fast(model, x, sigma_min, sigma_max, n, extra_args=None, callback
 
 
 @torch.no_grad()
-def sample_dpm_adaptive(model, x, sigma_min, sigma_max, extra_args=None, callback=None, disable=None, order=3, rtol=0.05, atol=0.0078, h_init=0.05, pcoeff=0., icoeff=1., dcoeff=0., accept_safety=0.81, eta=0., s_noise=1., noise_sampler=None, return_info=False):
+def sample_dpm_adaptive(model: BaseModelWrapper, x, sigma_min, sigma_max, extra_args=None, callback=None, disable=None, order=3, rtol=0.05, atol=0.0078, h_init=0.05, pcoeff=0., icoeff=1., dcoeff=0., accept_safety=0.81, eta=0., s_noise=1., noise_sampler=None, return_info=False):
     """DPM-Solver-12 and 23 (adaptive step size). See https://arxiv.org/abs/2206.00927."""
     if sigma_min <= 0 or sigma_max <= 0:
         raise ValueError('sigma_min and sigma_max must not be 0')
@@ -506,7 +511,7 @@ def sample_dpm_adaptive(model, x, sigma_min, sigma_max, extra_args=None, callbac
 
 
 @torch.no_grad()
-def sample_dpmpp_2s_ancestral(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
+def sample_dpmpp_2s_ancestral(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None):
     """Ancestral sampling with DPM-Solver++(2S) second-order steps."""
     extra_args = {} if extra_args is None else extra_args
     noise_sampler = default_noise_sampler(x) if noise_sampler is None else noise_sampler
@@ -540,7 +545,7 @@ def sample_dpmpp_2s_ancestral(model, x, sigmas, extra_args=None, callback=None, 
 
 
 @torch.no_grad()
-def sample_dpmpp_sde(model, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None, r=1 / 2):
+def sample_dpmpp_sde(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler=None, r=1 / 2):
     """DPM-Solver++ (stochastic)."""
     sigma_min, sigma_max = sigmas[sigmas > 0].min(), sigmas.max()
     noise_sampler = BrownianTreeNoiseSampler(x, sigma_min, sigma_max) if noise_sampler is None else noise_sampler
@@ -582,7 +587,7 @@ def sample_dpmpp_sde(model, x, sigmas, extra_args=None, callback=None, disable=N
 
 
 @torch.no_grad()
-def sample_dpmpp_2m(model, x, sigmas, extra_args=None, callback=None, disable=None, warmup_lms=False):
+def sample_dpmpp_2m(model: BaseModelWrapper, x, sigmas, extra_args=None, callback=None, disable=None, warmup_lms=False):
     """DPM-Solver++(2M)."""
     extra_args = {} if extra_args is None else extra_args
     s_in = x.new_ones([x.shape[0]])


### PR DESCRIPTION
_Note: for a cleaner diff: merge-base of this PR is set to an unrelated branch in my repository, rather than upstreaming to [crowsonkb/k-diffusion](https://github.com/crowsonkb/k-diffusion). because this branch is downstream of my Mac fixes and miscellany._

I made the model wrapper generic, so that you get auto-completion from `inner_model`:  
<img width="518" alt="image" src="https://github.com/Birch-san/k-diffusion/assets/6141784/faf40b08-a6c1-44bd-9aed-96d4ad3e0513">

somewhat worried about this:

```python
sigma_hat = model.discretize_sigma(sigma_hat)
```

since using `quantize=True` and `churn=0.`: we should expect this to be a no-op.

yet, there's a slight difference (see nose) when we apply this roundtrip to the sigma (left = usual, right = discretization):  
<img width="200px" src="https://github.com/Birch-san/k-diffusion/assets/6141784/8213f54e-9805-4e81-93cf-209fd0772a1c" title="not discretized"> <img width="200px" src="https://github.com/Birch-san/k-diffusion/assets/6141784/15df40bf-cee9-4cd0-b2df-e93f3a4326a1" title="discretized">

when churn>0, the difference is, uh, more dramatic (left = discretized, churn=0; right = discretized, churn = 0.1):  
<img width="200px" src="https://github.com/Birch-san/k-diffusion/assets/6141784/15df40bf-cee9-4cd0-b2df-e93f3a4326a1" title="discretized, churn=0"> <img width="200px" src="https://github.com/Birch-san/k-diffusion/assets/6141784/f8c41d1f-c7a5-4254-a9ca-5e7c5ae86346" title="discretized, churn=0.1">

churn>0 _does_ work if I remove the discretization (left = non-discretized, churn=0; right = non-discretized, churn = 0.1):  
<img width="200px" src="https://github.com/Birch-san/k-diffusion/assets/6141784/8213f54e-9805-4e81-93cf-209fd0772a1c" title="not discretized, churn=0"> <img width="200px" src="https://github.com/Birch-san/k-diffusion/assets/6141784/0ab46d38-5c77-44cb-919b-72bc6f55561f" title="not discretized, churn=0.1">